### PR TITLE
add support for macOS (darwin) platform

### DIFF
--- a/hidapi.py
+++ b/hidapi.py
@@ -2,7 +2,7 @@ from cffi import FFI
 from sys import platform
 ffi = FFI()
 
-if platform.startswith('linux'):
+if platform.startswith('linux') or platform.startswith('darwin'):
     ffi.cdef("""
 
 struct hid_device_;


### PR DESCRIPTION
The Linux code seems to work on macOS as well. I tested with the hidapi library installed via homebrew (`brew install hidapi`).